### PR TITLE
Fix Dockerfile to start the server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,5 @@ ENV PYTHONPATH "${PYTHONPATH}:/usr/local/lib/python3.10/site-packages"
 RUN dos2unix ./entrypoint.sh
 
 ENTRYPOINT [ "./entrypoint.sh" ]
+
+CMD cron && poetry run python3 manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Previously, the development server failed to start when the router container was built directly from the Dockerfile (instead of using docker-compose). To address this, a command has been added to the Dockerfile to start the Django server when the container is started

To reproduce the issue fixed in this PR, these steps can be followed:
```
docker pull postgres:latest

docker network create friendlyfl-controller_network

docker run --name postgres --network friendlyfl-controller_network -e POSTGRES_PASSWORD=UCalgary123 -e POSTGRES_USER=postgres -e POSTGRES_DB=friendlyfl-router -d postgres

docker build -t friendlyfl-router:latest .

docker run -it -p 8000:8000 --network friendlyfl-controller_network --name friendlyflrouter docker.io/library/friendlyfl-router:latest

```